### PR TITLE
feat: Terminal Documentation Viewer with GitHub Integration

### DIFF
--- a/src/features/docs.ts
+++ b/src/features/docs.ts
@@ -5,61 +5,291 @@
 
 import axios from 'axios';
 import { marked } from 'marked';
-import markedTerminal from 'marked-terminal';
+import TerminalRenderer from 'marked-terminal';
 import chalk from 'chalk';
 import open from 'open';
 import inquirer from 'inquirer';
 import { error, info, success, warning } from '../core/ui.js';
 
 // 配置marked使用终端渲染器
-marked.use(markedTerminal as any);
+marked.setOptions({
+  // @ts-ignore - markedTerminal类型定义问题
+  renderer: new TerminalRenderer()
+});
 
 /**
- * 文档列表（硬编码常用文档）
+ * GitHub仓库配置
  */
-const DOCS_LIST = [
-  { name: '返回主菜单', value: 'back' },
-  { name: '在浏览器中打开知识库', value: 'browser' }
-];
+const GITHUB_REPO = {
+  owner: 'nbtca',
+  repo: 'documents',
+  branch: 'main'
+};
 
 /**
- * 获取文档列表
+ * 文档结构类型
  */
-export async function fetchDocs(): Promise<string[]> {
-  // 简化版：返回预设的文档列表
-  // 实际项目中可以从API动态获取
-  return [
-    '首页',
-    '技术文档',
-    '教程资源'
-  ];
+interface DocItem {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+  sha?: string;
 }
 
 /**
- * 查看指定文档
+ * 预定义的文档分类
  */
-export async function viewDoc(path: string): Promise<void> {
-  try {
-    info(`正在加载文档: ${path}`);
+const DOC_CATEGORIES = [
+  { name: '[Tutorial]    教程', path: 'tutorial' },
+  { name: '[Repair]      维修日', path: '维修日' },
+  { name: '[Events]      相关活动举办', path: '相关活动举办' },
+  { name: '[Process]     流程文档', path: 'process' },
+  { name: '[Repair]      维修相关', path: 'repair' },
+  { name: '[Archive]     归档文档', path: 'archived' },
+  { name: '[README]      项目说明', path: 'README.md' }
+];
 
-    const response = await axios.get(`https://docs.nbtca.space/${path}`, {
+/**
+ * 从GitHub获取目录内容
+ */
+async function fetchGitHubDirectory(path: string = ''): Promise<DocItem[]> {
+  const url = `https://api.github.com/repos/${GITHUB_REPO.owner}/${GITHUB_REPO.repo}/contents/${path}?ref=${GITHUB_REPO.branch}`;
+
+  try {
+    const response = await axios.get(url, {
       timeout: 10000,
       headers: {
-        'User-Agent': 'NBTCA-CLI/2.3.1'
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'NBTCA-CLI'
       }
     });
 
-    console.log('\r' + ' '.repeat(50) + '\r'); // 清除加载提示
+    return response.data
+      .filter((item: any) => {
+        // 过滤掉 node_modules, .git 等目录
+        if (item.name.startsWith('.')) return false;
+        if (item.name === 'node_modules') return false;
+        if (item.name === 'package.json') return false;
+        if (item.name === 'pnpm-lock.yaml') return false;
 
-    // 渲染Markdown
-    const rendered = marked(response.data);
+        // 只显示目录和 markdown 文件
+        if (item.type === 'file' && !item.name.endsWith('.md')) return false;
+
+        return true;
+      })
+      .map((item: any) => ({
+        name: item.name,
+        path: item.path,
+        type: item.type === 'dir' ? 'dir' : 'file',
+        sha: item.sha
+      }))
+      .sort((a: DocItem, b: DocItem) => {
+        // 目录排在前面
+        if (a.type === 'dir' && b.type === 'file') return -1;
+        if (a.type === 'file' && b.type === 'dir') return 1;
+        return a.name.localeCompare(b.name);
+      });
+  } catch (err: any) {
+    throw new Error(`无法获取目录内容: ${err.message}`);
+  }
+}
+
+/**
+ * 从GitHub获取文件原始内容
+ */
+async function fetchGitHubRawContent(path: string): Promise<string> {
+  const url = `https://raw.githubusercontent.com/${GITHUB_REPO.owner}/${GITHUB_REPO.repo}/${GITHUB_REPO.branch}/${path}`;
+
+  try {
+    const response = await axios.get(url, {
+      timeout: 15000,
+      headers: {
+        'User-Agent': 'NBTCA-CLI'
+      }
+    });
+
+    return response.data;
+  } catch (err: any) {
+    throw new Error(`无法获取文件内容: ${err.message}`);
+  }
+}
+
+/**
+ * 清理和格式化Markdown内容
+ * 移除VitePress frontmatter和特殊语法，优化终端显示
+ */
+function cleanMarkdownContent(content: string): string {
+  let cleaned = content;
+
+  // 1. 移除 YAML frontmatter (---开头结尾的部分)
+  cleaned = cleaned.replace(/^---\n[\s\S]*?\n---\n/m, '');
+
+  // 2. 移除 VitePress 的特殊容器语法 (:::info, :::tip, :::warning 等)
+  // 保留内容，只移除容器标记
+  cleaned = cleaned.replace(/^:::(info|tip|warning|danger|details).*$/gm, '');
+  cleaned = cleaned.replace(/^:::$/gm, '');
+
+  // 3. 处理 VitePress 的 [[toc]] 语法
+  cleaned = cleaned.replace(/\[\[toc\]\]/gi, '**目录**\n\n_(请在浏览器中查看完整目录)_\n');
+
+  // 4. 清理多余的空行（超过2个连续空行压缩为2个）
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+
+  // 5. 移除 HTML 注释
+  cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, '');
+
+  // 6. 清理开头和结尾的空白
+  cleaned = cleaned.trim();
+
+  return cleaned;
+}
+
+/**
+ * 提取文档标题（从第一个 # 标题）
+ */
+function extractDocTitle(content: string): string | null {
+  const match = content.match(/^#\s+(.+)$/m);
+  return match?.[1]?.trim() ?? null;
+}
+
+/**
+ * 浏览目录并选择文档
+ */
+async function browseDirectory(dirPath: string = ''): Promise<void> {
+  try {
+    info(dirPath ? `正在加载目录: ${dirPath}` : '正在加载文档列表...');
+
+    const items = await fetchGitHubDirectory(dirPath);
+
+    console.log('\r' + ' '.repeat(60) + '\r'); // 清除加载提示
+
+    if (items.length === 0) {
+      warning('该目录为空');
+      return;
+    }
+
+    // 构建选择列表
+    const choices = [
+      ...(dirPath ? [
+        { name: chalk.gray('[..] Up to parent directory'), value: { type: 'back' } },
+        new inquirer.Separator()
+      ] : []),
+      ...items.map(item => ({
+        name: item.type === 'dir'
+          ? chalk.cyan(`[DIR] ${item.name}/`)
+          : chalk.white(`[MD]  ${item.name}`),
+        value: item
+      })),
+      new inquirer.Separator(),
+      { name: chalk.gray('[ ^] Return to main menu'), value: { type: 'exit' } }
+    ];
+
+    const { selected } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'selected',
+        message: dirPath ? `当前目录: ${dirPath}` : '选择文档或目录:',
+        choices,
+        pageSize: 15,
+        loop: false
+      }
+    ]);
+
+    // 处理用户选择
+    if (selected.type === 'exit') {
+      return;
+    } else if (selected.type === 'back') {
+      // 返回上级目录
+      const parentPath = dirPath.split('/').slice(0, -1).join('/');
+      await browseDirectory(parentPath);
+    } else if (selected.type === 'dir') {
+      // 进入子目录
+      await browseDirectory(selected.path);
+    } else if (selected.type === 'file') {
+      // 查看文件
+      await viewMarkdownFile(selected.path);
+      // 查看完后继续浏览当前目录
+      await browseDirectory(dirPath);
+    }
+
+  } catch (err: any) {
+    error('无法加载目录');
+    console.log(chalk.gray(`  错误: ${err.message}`));
+
+    const { retry } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'retry',
+        message: '是否重试？',
+        default: true
+      }
+    ]);
+
+    if (retry) {
+      await browseDirectory(dirPath);
+    }
+  }
+}
+
+/**
+ * 查看Markdown文件
+ */
+async function viewMarkdownFile(path: string): Promise<void> {
+  try {
+    info(`正在加载: ${path}`);
+
+    // 从GitHub获取原始Markdown内容
+    const rawContent = await fetchGitHubRawContent(path);
+
+    // 清理VitePress特殊语法
+    const cleanedContent = cleanMarkdownContent(rawContent);
+
+    // 提取标题
+    const title = extractDocTitle(cleanedContent) || path.split('/').pop() || path;
+
+    console.clear();
+    console.log();
+    console.log(chalk.cyan.bold(`>> ${title}`));
+    console.log(chalk.gray(`   ${path}`));
+    console.log();
+    console.log(chalk.gray('='.repeat(80)));
+    console.log();
+
+    // 渲染Markdown到终端
+    const rendered = marked(cleanedContent);
     console.log(rendered);
+    console.log();
+    console.log(chalk.gray('='.repeat(80)));
+    console.log();
+    console.log(chalk.dim('  Note: Some features are only available in browser'));
     console.log();
 
     success('文档加载完成');
-  } catch (err) {
+    console.log();
+
+    // 提供后续操作选项
+    const { action } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'action',
+        message: '选择操作:',
+        choices: [
+          { name: '[ <] Back to docs list', value: 'back' },
+          { name: '[ *] Open in browser', value: 'browser' }
+        ]
+      }
+    ]);
+
+    if (action === 'browser') {
+      await openDocsInBrowser(path);
+    }
+
+  } catch (err: any) {
+    console.log('\r' + ' '.repeat(60) + '\r');
     error('无法加载文档');
+    console.log(chalk.gray(`  错误: ${err.message}`));
     warning('建议在浏览器中查看');
+    console.log();
 
     const { openBrowser } = await inquirer.prompt([
       {
@@ -71,7 +301,7 @@ export async function viewDoc(path: string): Promise<void> {
     ]);
 
     if (openBrowser) {
-      await openDocsInBrowser();
+      await openDocsInBrowser(path);
     }
   }
 }
@@ -79,10 +309,13 @@ export async function viewDoc(path: string): Promise<void> {
 /**
  * 在浏览器中打开知识库
  */
-export async function openDocsInBrowser(): Promise<void> {
+export async function openDocsInBrowser(path?: string): Promise<void> {
   try {
     info('正在打开浏览器...');
-    await open('https://docs.nbtca.space');
+    const url = path
+      ? `https://docs.nbtca.space/${path.replace(/\.md$/, '')}`
+      : 'https://docs.nbtca.space';
+    await open(url);
     success('已在浏览器中打开知识库');
   } catch (err) {
     error('无法打开浏览器');
@@ -95,26 +328,42 @@ export async function openDocsInBrowser(): Promise<void> {
  * 显示知识库菜单
  */
 export async function showDocsMenu(): Promise<void> {
-  while (true) {
-    console.log();
-    console.log(chalk.cyan.bold('  知识库'));
-    console.log();
+  console.log();
+  console.log(chalk.cyan.bold('  >> Knowledge Base'));
+  console.log(chalk.dim('     Browse documentation from terminal or open in browser'));
+  console.log();
 
-    const { action } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'action',
-        message: '选择操作:',
-        choices: DOCS_LIST,
-        pageSize: 10
-      }
-    ]);
+  const choices = [
+    ...DOC_CATEGORIES.map(cat => ({
+      name: cat.name,
+      value: cat.path
+    })),
+    new inquirer.Separator(),
+    { name: chalk.gray('[ *] Open in browser'), value: 'browser' },
+    { name: chalk.gray('[ ^] Back to main menu'), value: 'back' }
+  ];
 
-    if (action === 'back') {
-      break;
-    } else if (action === 'browser') {
-      await openDocsInBrowser();
-      break;
+  const { action } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'action',
+      message: '选择文档分类:',
+      choices,
+      pageSize: 15,
+      loop: false
     }
+  ]);
+
+  if (action === 'back') {
+    return;
+  } else if (action === 'browser') {
+    await openDocsInBrowser();
+  } else if (action === 'README.md') {
+    // 直接查看 README
+    await viewMarkdownFile('README.md');
+  } else {
+    // 浏览指定目录
+    await browseDirectory(action);
   }
 }
+


### PR DESCRIPTION
## Summary

Add comprehensive terminal-based documentation viewer that allows users to browse and read Markdown files from the nbtca/documents repository directly in the terminal, eliminating the need to open a browser.

## Features Implemented

- **GitHub API Integration**: Fetch directory structure and file contents from nbtca/documents repository
- **Directory Tree Navigation**: Browse documentation categories with recursive directory navigation
- **VitePress Syntax Cleaning**: Remove frontmatter, containers (:::info, :::tip), [[toc]], and HTML comments for clean terminal rendering
- **Terminal Markdown Rendering**: Use marked-terminal for readable terminal output
- **Browser Fallback**: Automatically offer to open browser on network errors or user preference
- **Retry Mechanism**: Handle failed network requests gracefully

## Technical Details

- Uses GitHub Contents API and raw.githubusercontent.com for fetching
- Implements `cleanMarkdownContent()` to strip VitePress-specific syntax
- Recursive `browseDirectory()` function for stateless navigation
- ASCII symbols: [DIR], [MD], [..], [ <], [ ^], [ *]
- Integration with existing menu system

## Testing Instructions

1. Run `pnpm run dev`
2. Select "[*] Knowledge Base" from main menu
3. Navigate through categories using arrow keys or j/k
4. Select any .md file to view rendered content
5. Test back navigation with [..] and [ ^] options
6. Test browser fallback with "[ *] Open in browser"

## Files Changed

- `src/features/docs.ts`: Complete rewrite with full implementation

## Related Issues

Implements terminal documentation viewing as requested for better developer experience and terminal-first workflow.