### PR TITLE
chore: release v1.0.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nbtca/prompt",
-  "version": "1.0.19",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nbtca/prompt",
-      "version": "1.0.19",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nbtca/prompt",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump version to 1.0.21 to publish fix for vim keys crash on Node.js v25 (see #14).